### PR TITLE
update global css for images

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,3 +2,7 @@ body,
 div#___gatsby {
   background: #faf0fd;
 }
+
+img.gatsby-resp-image-image {
+  object-fit: contain;
+}


### PR DESCRIPTION
[Problem]
<img width="751" alt="Screenshot 2020-02-10 at 10 49 39" src="https://user-images.githubusercontent.com/22022930/74120289-5a2a1700-4bf5-11ea-81e2-3e21ea743fec.png">

I'm not familiar with Gatsby styling best practices, just applied this property globally seems ok with me. Of course, if you have better approach or this is not your way of applying custom CSS - that's understandable.
apply object-fit: contain property for generated  .gatsby-resp-image-image classes

p.s. really enjoy your blog-posting, thanks for sharing your knowledge!